### PR TITLE
Use ProPublica API to put House/Senate into the database

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,14 +46,19 @@ gem "decent_exposure"
 # Committee/subcommittee relationship
 gem "ancestry"
 
+# For retrieving and parsing ProPublica Senate/House committee data
+gem "httparty"
+gem "oj"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "rspec-rails"
-  # gem 'cypress-on-rails'
   gem "factory_bot_rails"
   gem "rubocop", "~> 0.56.0", require: false
   gem "rubocop-rails"
+  gem "pry-rails"
+  gem "binding_of_caller"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,9 +50,11 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.6.1)
+    autoprefixer-rails (8.6.2)
       execjs
     bindex (0.5.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
     bootstrap (4.1.1)
@@ -73,6 +75,7 @@ GEM
     chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -82,7 +85,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
-    database_cleaner (1.5.3)
+    database_cleaner (1.7.0)
+    debug_inspector (0.0.3)
     decent_exposure (3.0.2)
       activesupport (>= 4.0)
     diff-lcs (1.3)
@@ -96,6 +100,8 @@ GEM
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    httparty (0.16.2)
+      multi_xml (>= 0.5.2)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -124,15 +130,22 @@ GEM
     minitest (5.11.3)
     msgpack (1.2.4)
     multi_json (1.13.1)
+    multi_xml (0.6.0)
     nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    oj (3.6.2)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     pg (1.0.0)
     popper_js (1.12.9)
     powerpack (0.1.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
     rack (2.0.5)
@@ -258,6 +271,7 @@ PLATFORMS
 
 DEPENDENCIES
   ancestry
+  binding_of_caller
   bootsnap (>= 1.1.0)
   bootstrap
   byebug
@@ -267,10 +281,13 @@ DEPENDENCIES
   database_cleaner
   decent_exposure
   factory_bot_rails
+  httparty
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  oj
   pg (>= 0.18, < 2.0)
+  pry-rails
   puma (~> 3.11)
   rails (~> 5.2.0)
   rspec-rails

--- a/app/lib/committee_loader.rb
+++ b/app/lib/committee_loader.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# The CommmitteeLoader is used to load House/Senate committee/subcommittee
+# relationships using data populated from the free ProPublica API.
+#
+# https://github.com/rails/rails/issues/13142#issuecomment-29969951
+#
+# Example usage:
+#
+#   CommitteeLoader.load(chamber: :house, parent: Committee.find_by(name: "House"))
+class CommitteeLoader
+  attr_reader :session, :chamber, :parent
+
+  # Convenience, allowing CommitteeLoader.load(...) syntax
+  class << self
+    def load(session: 115, chamber:, parent:)
+      new(session: session, chamber: chamber, parent: parent).load
+    end
+  end
+
+  def initialize(session: 115, chamber:, parent:)
+    @session = session
+    @chamber = chamber
+    @parent = parent
+  end
+
+  def load
+    committee_response = HTTParty.get(url, headers).body
+
+    committees = Oj.load(committee_response)["results"][0]["committees"]
+
+    committees.each do |committee|
+      new_committee = Committee.create!(name: committee["name"], code: committee["code"], website: committee["url"], parent: parent)
+
+      committee["subcommittees"].each do |sub|
+
+        sub_response = HTTParty.get(sub["api_uri"], headers).body
+
+        sub_result = Oj.load(sub_response)["results"][0]
+
+        # NOTE: I don't think the subcommittees actually have a website,
+        # but should investigate these subcommittee results further
+        subcommittee = Committee.create!(name: sub_result["name"], code: sub_result["id"], parent: new_committee)
+      end
+    end
+  end
+
+  private
+
+    def url
+      "https://api.propublica.org/congress/v1/#{session}/#{chamber}/committees.json"
+    end
+
+    # ProPublica API requires the API key in the headers
+    def headers
+      { headers: { "X-API-Key" => ENV.fetch("PROPUBLICA_API_KEY") } }
+    end
+end

--- a/lib/tasks/committees.rake
+++ b/lib/tasks/committees.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# These rake tasks populate the House/Senate relationships from the ProPublica
+# free API (registration & API key required). By default, they point to the
+# House/Senate children of the 115th Session. This should be refactored for
+# extensiblity if needed later.
+
+namespace "committees" do
+  namespace "house" do
+    desc "Load House Committees and Subcommittees"
+    task :load do
+      CommitteeLoader.load(chamber: :house, parent: Committee.find_by(name: "House"))
+    end
+  end
+
+  namespace "senate" do
+    desc "Load Senate Committees and Subcommittees"
+    task :load do
+      CommitteeLoader.load(chamber: :senate, parent: Committee.find_by(name: "Senate"))
+    end
+  end
+end


### PR DESCRIPTION
Testing this:

- Get a free API key: https://projects.propublica.org/api-docs/congress-api/#get-an-api-key
- Set your API key as an environment variable (`export PROPUBLICA_API_KEY="key_here"`)
- Run `bin/setup` to make sure your database is seeded with base Congress/House/Senate records
- Run `rake committees:house:load` and then `rake committees:senate:load` to load the House and Senate committee & subcommittees